### PR TITLE
fix: add timeout for API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ If you wish to use a custom domain to serve your images you need to add the foll
 
 ```python
 CLOUDFLARE_IMAGES_DOMAIN = "example.com"
-
 ```
 
 If you wish to use a default variant other than "public" to serve your images you need to add the following to your settings.py:
@@ -67,6 +66,11 @@ If you wish to use a default variant other than "public" to serve your images yo
 CLOUDFLARE_IMAGES_VARIANT = "custom"
 ```
 
+If you wish to override the default timeout of 60 seconds for API requests, you need to add the following to your settings.py:
+
+```python
+CLOUDFLARE_IMAGES_API_TIMEOUT = 120
+```
 ## Development
 
 Installing for development:

--- a/cloudflare_images/config.py
+++ b/cloudflare_images/config.py
@@ -52,3 +52,14 @@ class Config:
             if hasattr(settings, "CLOUDFLARE_IMAGES_VARIANT")
             else "public"
         )
+
+    @property
+    def api_timeout(self):
+        """
+        Returns the timeout if set, else a default of 60 seconds
+        """
+        return (
+            settings.CLOUDFLARE_IMAGES_API_TIMEOUT
+            if hasattr(settings, "CLOUDFLARE_IMAGES_API_TIMEOUT")
+            else 60
+        )

--- a/cloudflare_images/service.py
+++ b/cloudflare_images/service.py
@@ -37,7 +37,7 @@ class CloudflareImagesService:
 
         files = {"file": file}
 
-        response = requests.post(url, headers=headers, files=files)
+        response = requests.post(url, headers=headers, timeout=self.config.api_timeout, files=files)
 
         status_code = response.status_code
         if status_code != 200:
@@ -66,7 +66,7 @@ class CloudflareImagesService:
 
         url = self.get_url(name, variant or self.config.variant)
 
-        response = requests.get(url)
+        response = requests.get(url, timeout=self.config.api_timeout)
 
         status_code = response.status_code
         if status_code != 200:
@@ -85,7 +85,7 @@ class CloudflareImagesService:
 
         headers = {"Authorization": "Bearer {}".format(self.config.api_token)}
 
-        response = requests.delete(url, headers=headers)
+        response = requests.delete(url, timeout=self.config.api_timeout, headers=headers)
 
         status_code = response.status_code
         if status_code != 200:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -43,3 +43,12 @@ class ConfigTests(TestCase):
     def test_custom_variant(self):
         variant = self.config.variant
         self.assertEqual(variant, "custom")
+
+    def test_api_timeout(self):
+        api_timeout = self.config.api_timeout
+        self.assertEqual(api_timeout, 60)
+
+    @override_settings(CLOUDFLARE_IMAGES_API_TIMEOUT=100)
+    def test_custom_api_timeout(self):
+        api_timeout = self.config.api_timeout
+        self.assertEqual(api_timeout, 100)


### PR DESCRIPTION
This PR adds a timeout for API requests as recommended in the docs:

> Nearly all production code should use this parameter in nearly all requests. Failure to do so can cause your program to hang indefinitely.
https://requests.readthedocs.io/en/latest/user/quickstart/#timeouts