### PR TITLE
Fix typos and grammar in docstrings

### DIFF
--- a/cloudflare_images/config.py
+++ b/cloudflare_images/config.py
@@ -69,7 +69,7 @@ class Config:
         """
         Returns the endpoint used to retrieve the upload URL from cloudflare
         This library provides a default one which has NO SECURITY,
-        is it therefore highly recommended to implement your own.
+        it is therefore highly recommended to implement your own.
         """
         return (
             settings.CLOUDFLARE_IMAGES_UPLOAD_ENDPOINT

--- a/cloudflare_images/service.py
+++ b/cloudflare_images/service.py
@@ -29,7 +29,7 @@ class CloudflareImagesService:
 
     def upload(self, file: File) -> str:
         """
-        Uploads a file and return its name, otherwise raise an exception
+        Uploads a file and returns its name, otherwise raises an exception
         """
         url = "https://api.cloudflare.com/client/v4/accounts/{}/images/v1".format(
             self.config.account_id
@@ -65,7 +65,7 @@ class CloudflareImagesService:
 
     def open(self, name: str, variant: str | None = None) -> bytes:
         """
-        Retrieves a file and return its content, otherwise raise an exception
+        Retrieves a file and returns its content, otherwise raises an exception
         """
 
         url = self.get_url(name, variant or self.config.variant)

--- a/cloudflare_images/storage.py
+++ b/cloudflare_images/storage.py
@@ -19,7 +19,7 @@ class CloudflareImagesStorage(Storage):
 
     def __init__(self) -> None:
         """
-        Setups the storage
+        Sets up the storage
         """
         super().__init__()
 
@@ -29,7 +29,7 @@ class CloudflareImagesStorage(Storage):
         """
         Returns the image as a File
         The parameter "mode" has been kept to respect the original signature
-        (and it fails without it) but it wont have any impact
+        (and it fails without it) but it won't have any impact
         Has to be implemented.
         """
         content = self.service.open(name)


### PR DESCRIPTION
## Summary
- Fix `Setups` → `Sets up` in storage.py docstring
- Fix `wont` → `won't` in storage.py docstring
- Fix `return` → `returns` in service.py docstring
- Fix `raise` → `raises` (×2) in service.py docstring
- Fix `is it therefore` → `it is therefore` in config.py docstring

Docstrings only — no functional changes.